### PR TITLE
[depends] Fix debug build for bSNES Mercury

### DIFF
--- a/depends/common/bsnes-mercury/CMakeLists.txt
+++ b/depends/common/bsnes-mercury/CMakeLists.txt
@@ -9,7 +9,7 @@ enable_language(CXX)
 include(ExternalProject)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  set(LIBRETRO_DEBUG DEBUG=1)
+  set(LIBRETRO_DEBUG debug=1)
 endif()
 
 if("${CORE_SYSTEM_NAME}" STREQUAL "windows")


### PR DESCRIPTION
Makefile variables are case sensitive. bSNES Mercury uses 'debug'.
(https://github.com/libretro/bsnes-mercury/blob/master/Makefile#L29)
